### PR TITLE
Remove autumn auditions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,3 @@
   to = "https://wiki.dissonanssi.fi"
   status = 302
   force = true
-
-[[redirects]]
-  from = "/koelaulut"
-  to = "https://forms.gle/Ct8C89epW1UBBTP1A"
-  status = 302
-  force = true

--- a/public/en/liity.html
+++ b/public/en/liity.html
@@ -25,15 +25,6 @@
 			</div>
 
 			<!-- Timely audition info -->
-			<!--
-			<div class="text">
-				<div class="pad">
-					<h2>Autumn 2024 auditions</h2>
-					<p>This autumn we are recruiting all vocal ranges. The Auditions will be held on thursday 12.09. at 17-21 in Stage in Design Factory. Applicants are given phased time slots to avoid pointless waiting. <a href="../koelaulut">Sign up to audition</a></p>
-					<p>Come meet us in our open rehersals on tue 10.9. at 18-20:30 in AS2 lecture hall located in TUAS (Maarintie 8).</p>
-				</div>
-			</div>
-			-->
 
 			<!-- Constant audition info -->
 			<div class="text">

--- a/public/en/liity.html
+++ b/public/en/liity.html
@@ -25,6 +25,7 @@
 			</div>
 
 			<!-- Timely audition info -->
+			<!--
 			<div class="text">
 				<div class="pad">
 					<h2>Autumn 2024 auditions</h2>
@@ -32,6 +33,7 @@
 					<p>Come meet us in our open rehersals on tue 10.9. at 18-20:30 in AS2 lecture hall located in TUAS (Maarintie 8).</p>
 				</div>
 			</div>
+			-->
 
 			<!-- Constant audition info -->
 			<div class="text">

--- a/public/liity.html
+++ b/public/liity.html
@@ -25,15 +25,6 @@
 			</div>
 
 			<!-- Timely audition info -->
-			<!--
-			<div class="text">
-				<div class="pad">
-					<h2>Syksyn 2024 koelaulut</h2>
-					<p>Tänä syksynä haemme kaikkia äänialoja. Syksyn koelaulut järjestetään torstaina 12.09. klo 17-21 Design Factoryn Stagessa. Hakijoille annetaan porrastettu saapumisaika turhan odottelun välttämiseksi. <a href="koelaulut">Ilmoittaudu koelauluihin</a></p>
-					<p>Tervetuloa tutustumaan kuoroon avoimissa harjoituksissa ti 10.9. klo 18-20:30 AS2-saliin TUAS-taloon (Maarintie 8).</p>
-				</div>
-			</div>
-			-->
 
 			<!-- Constant audition info -->
 			<div class="text">

--- a/public/liity.html
+++ b/public/liity.html
@@ -25,6 +25,7 @@
 			</div>
 
 			<!-- Timely audition info -->
+			<!--
 			<div class="text">
 				<div class="pad">
 					<h2>Syksyn 2024 koelaulut</h2>
@@ -32,6 +33,7 @@
 					<p>Tervetuloa tutustumaan kuoroon avoimissa harjoituksissa ti 10.9. klo 18-20:30 AS2-saliin TUAS-taloon (Maarintie 8).</p>
 				</div>
 			</div>
+			-->
 
 			<!-- Constant audition info -->
 			<div class="text">


### PR DESCRIPTION
Remove info about autumn 2024 auditions and the redirect.

Approve and merge to master later this year.